### PR TITLE
remove header from table and default sort data by -sample_type

### DIFF
--- a/mibios/glamr/tables.py
+++ b/mibios/glamr/tables.py
@@ -132,7 +132,6 @@ class DatasetTable(Table):
     )
     samples = Column(
         verbose_name='Available samples',
-        order_by=A('-sample_count'),
         attrs={
             'showFieldTitle': False,
             'cardTitle': False,

--- a/mibios/glamr/templates/glamr/table_cards.html
+++ b/mibios/glamr/templates/glamr/table_cards.html
@@ -33,30 +33,6 @@
 {% block table-wrapper %}
     <div class="container-fluid" >
         {% block table %}
-        {% block table.thead %}
-            {% if table.show_header %}
-                <div {{ table.attrs.thead.as_html }}>
-                    <div class="card bg-light mb-3">
-                        <div class="card-body p-2">
-                            <ul class="nav nav-pills" id="pills-tab">
-                            {% for column in table.columns %}
-                                    {% if column.orderable %}
-                                        <li class="nav-item">
-                                            <a class="sort nav-link" id={{ column.attrs.navID }} href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}<i id="{{column.attrs.navID}}-icon" class="icon-sort bi bi-caret-down m-1"></i></a>
-                                        </li>
-                                    {% else %}
-                                        <li class="nav-item">
-                                            <span class="nav-link" id={{ column.attrs.navID }} href="#">{{ column.header }}</span>
-                                        </li>
-                                    {% endif %}
-                            {% endfor %}
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            {% endif %}
-            {% endblock table.thead %}
-
             {% block table.tbody %}
                 <div class="row">
                     {% for row in table.paginated_rows %}

--- a/mibios/glamr/views.py
+++ b/mibios/glamr/views.py
@@ -870,7 +870,7 @@ class FrontPageView(SearchFormMixin, MapMixin, SingleTableView):
         self.filter = self.filter_class(self.request.GET, queryset=qs)
         self.filter.form.helper = self.formhelper_class()
 
-        return self.filter.qs.annotate(sample_count=Count('sample'))
+        return self.filter.qs.annotate(sample_count=Count('sample')).order_by("-sample_count")
 
     def get_context_data(self, **ctx):
         # Make the frontpage resilient to database connection issues: Any DB


### PR DESCRIPTION
I removed the sortable headers from the front page table template and also sorted the front page data by -sample_count.