### PR TITLE
UI adv search

### DIFF
--- a/mibios/glamr/search_fields.py
+++ b/mibios/glamr/search_fields.py
@@ -52,6 +52,13 @@ SEARCH_FIELDS = {
 }
 
 
+ADVANCED_SEARCH_MODELS = [
+    'dataset', 'sample', 'reference', 'compoundname', 'contig',
+    'functionname', 'gene', 'taxname',
+]
+""" names of models we offer for the advanced search """
+
+
 def print():
     """ helper go generate SEARCH_FIELD """
     r = get_registry()

--- a/mibios/glamr/tables.py
+++ b/mibios/glamr/tables.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from django.utils.html import escape, format_html, mark_safe
 
-from django_tables2 import A, Column, Table, TemplateColumn
+from django_tables2 import Column, Table, TemplateColumn
 
 from mibios.glamr import models as glamr_models
 from mibios.omics import models as omics_models
@@ -201,7 +201,7 @@ class DatasetTable(Table):
         for accession, url in value:
             if url:
                 items.append(
-                    format_html('<a href="{}" class="card-link">{}</a>', url, accession)
+                    format_html('<a href="{}" class="card-link">{}</a>', url, accession)  # noqa: E501
                 )
             else:
                 items.append(escape(accession))
@@ -223,10 +223,10 @@ class DatasetTable(Table):
 
     def render_samples(self, record):
         if record.sample_count <= 0:
-            return mark_safe('<div class="btn btn-primary disabled mb-1">No samples</div>')
+            return mark_safe('<div class="btn btn-primary disabled mb-1">No samples</div>')  # noqa: E501
 
         url = record.get_samples_url()
-        return mark_safe(f'<a href="{url}" class="btn btn-primary mb-1">{record.sample_count} available samples</a>')
+        return mark_safe(f'<a href="{url}" class="btn btn-primary mb-1">{record.sample_count} available samples</a>')  # noqa: E501
 
 
 def get_sample_url(sample):

--- a/mibios/glamr/tables.py
+++ b/mibios/glamr/tables.py
@@ -182,6 +182,7 @@ class DatasetTable(Table):
 
     class Meta:
         empty_text = 'No dataset / study information available'
+        template_name = 'glamr/table_cards.html'
         attrs = {
             "id": "overview-table",
             "class": "table table-hover",

--- a/mibios/glamr/templates/glamr/search_init.html
+++ b/mibios/glamr/templates/glamr/search_init.html
@@ -9,7 +9,7 @@
         Select a data category
     </button>
     <div class="dropdown-menu scrollable" aria-labelledby="dropdownMenuLink">
-        {% for name, verbose in models %}
+        {% for name, verbose in adv_search_models %}
             <a href="{% url 'search_model' model=name %}" class="dropdown-item">{{ verbose }}</a>
         {% endfor %}
     </div>

--- a/mibios/glamr/templates/glamr/table.html
+++ b/mibios/glamr/templates/glamr/table.html
@@ -2,15 +2,17 @@
 {% load render_table from django_tables2 %}
 {% block content %}
 <div class="container-fluid">
-<h2>{{ model_verbose_name_plural }}</h2>
-{% if qnode %}
-with filter:</br>
-{% include 'glamr/search_filter.html' %}
-(<a href="{% url 'search_model' model=model_name %}">change</a>)
-{% else %}
-all {{ model_verbose_name }} data shown (<a href="{% url 'search_model' model=model_name %}">add filter</a>)
-{% endif %}
-{% render_table table %}
+    <h2>{{ model_verbose_name_plural | capfirst }}</h2>
+        {% if qnode %}
+            with filter:</br>
+            {% include 'glamr/search_filter.html' %}
+            (<a href="{% url 'search_model' model=model_name %}">change</a>)
+            <h4 class="mt-1 mb-2">Found {{ object_list | length }} records:</h4>
+        {% else %}
+        <h4 class="mt-1 mb-2">All records shown</h4>
+        (<a href="{% url 'search_model' model=model_name %}">add filter</a>)
+        {% endif %}
+        {% render_table table %}
 </div>
 {% endblock %}
 

--- a/mibios/glamr/views.py
+++ b/mibios/glamr/views.py
@@ -890,7 +890,7 @@ class FrontPageView(SearchFormMixin, MapMixin, SingleTableView):
         self.filter = self.filter_class(self.request.GET, queryset=qs)
         self.filter.form.helper = self.formhelper_class()
 
-        return self.filter.qs.annotate(sample_count=Count('sample')).order_by("-sample_count")
+        return self.filter.qs.annotate(sample_count=Count('sample')).order_by("-sample_count")  # noqa: E501
 
     def get_context_data(self, **ctx):
         # Make the frontpage resilient to database connection issues: Any DB
@@ -1180,7 +1180,7 @@ class TableView(BaseFilterMixin, ModelTableMixin, SingleTableView):
         qs = self.conf.get_queryset()
 
         if self.model == models.Dataset:
-            qs = qs.annotate(sample_count=Count('sample')).order_by("-sample_count")
+            qs = qs.annotate(sample_count=Count('sample')).order_by("-sample_count")  # noqa:E501
 
         return qs
 

--- a/mibios/glamr/views.py
+++ b/mibios/glamr/views.py
@@ -31,7 +31,7 @@ from mibios.umrad.utils import DefaultDict
 from mibios.omics.models import Gene
 from . import models, tables
 from .forms import QBuilderForm, QLeafEditForm, SearchForm
-from .search_fields import SEARCH_FIELDS
+from .search_fields import ADVANCED_SEARCH_MODELS, SEARCH_FIELDS
 from .search_utils import get_suggestions
 from .url_utils import fast_reverse
 
@@ -1152,12 +1152,12 @@ class SearchView(TemplateView):
         ctx['models_and_fields'] = m_and_f
 
         # models in alphabetical order
-        model_list = [
-            (i._meta.model_name, i._meta.verbose_name)
-            for i in get_registry().models.values()
-        ]
-        model_list.sort(key=lambda item: item[1].lower())
-        ctx['models'] = model_list
+        models = get_registry().models
+        items = []
+        for i in ADVANCED_SEARCH_MODELS:
+            m = models[i]
+            items.append((m._meta.model_name, m._meta.verbose_name))
+        ctx['adv_search_models'] = sorted(items, key=lambda x: x[1].lower())
 
         return ctx
 


### PR DESCRIPTION
Not sure this is the best way to start building this out, but I figured we could reuse the front page "table cards" template to make dataset advanced search results more user friendly (and keep the pagination).

Should be merged after the remove-header-frontpage branch.