### PR TITLE
Count samples/datasets correctly on frontpage

### DIFF
--- a/mibios/glamr/views.py
+++ b/mibios/glamr/views.py
@@ -867,10 +867,12 @@ class FrontPageView(SearchFormMixin, MapMixin, SingleTableView):
             queryset=Sample.objects.only('dataset_id', 'sample_type'),
         ))
 
+        qs = qs.annotate(sample_count=Count('sample', distinct=True))
+
         self.filter = self.filter_class(self.request.GET, queryset=qs)
         self.filter.form.helper = self.formhelper_class()
-
-        return self.filter.qs.annotate(sample_count=Count('sample'))
+        
+        return self.filter.qs
 
     def get_context_data(self, **ctx):
         # Make the frontpage resilient to database connection issues: Any DB
@@ -917,7 +919,7 @@ class FrontPageView(SearchFormMixin, MapMixin, SingleTableView):
         ctx['dataset_counts'] = dataset_counts_data
 
         ctx['dataset_totalcount'] = Dataset.objects.count()
-        ctx['filtered_dataset_totalcount'] = self.filter.qs.count()
+        ctx['filtered_dataset_totalcount'] = self.filter.qs.distinct().count()
         ctx['sample_totalcount'] = Sample.objects.count()
 
         # Get context for sample summary


### PR DESCRIPTION
We needed to add an additional "distinct" to the count of datasets, and count samples before filtering.