### PR TITLE
Fit map bounds to points on pages besides frontpage

### DIFF
--- a/mibios/glamr/static/glamr/js/map.js
+++ b/mibios/glamr/static/glamr/js/map.js
@@ -9,9 +9,13 @@ const map = L.map("map", {
 	scrollWheelZoom: false 
 });
 L.control.scale().addTo(map);
+
+// load data and variables passed to the script
 const map_points = JSON.parse(
   document.currentScript.nextElementSibling.textContent
 );
+const data = document.currentScript.dataset;
+const fit_map_to_points = data.fit_map_to_points;
 
 // leaflet legend help from https://gis.stackexchange.com/questions/133630/adding-leaflet-legend
 var legend = L.control({position: 'bottomright'});
@@ -60,3 +64,9 @@ for (var i in map_points) {
 }
 
 var group = L.featureGroup(markers).addTo(map);
+
+// set map zoom/bounds using the points we added instead of the default
+// showing the Great Lakes, intended for the frontpage
+if(fit_map_to_points){
+        map.fitBounds(group.getBounds());
+}

--- a/mibios/glamr/templates/glamr/detail.html
+++ b/mibios/glamr/templates/glamr/detail.html
@@ -9,11 +9,11 @@
   </ol>
 </nav>
 
-{% block map%}{%if map_points%}{%include 'glamr/map.html'%}{%endif%}{%endblock%}
-
 {% block detail_header %}
 <h3>{{ object_model_verbose_name|capfirstsmart }}: {{ object }}</h3>
 {% endblock %}
+
+{% block map%}{%if map_points%}{%include 'glamr/map.html'%}{%endif%}{%endblock%}
 
 <div class="card mb-2 mt-2">
         <div style="display: flex; flex-direction: row" class="card-header">

--- a/mibios/glamr/templates/glamr/map.html
+++ b/mibios/glamr/templates/glamr/map.html
@@ -1,4 +1,4 @@
 {% load static %}
-<div id="map" class="map"></div>
-<script src="{% static 'glamr/js/map.js' %}" defer></script>
+<div id="map" class="map mb-1"></div>
+<script src="{% static 'glamr/js/map.js' %}" defer data-fit_map_to_points="{{ fit_map_to_points|default:"" }}"></script>
 {{ map_points|json_script:"" }}

--- a/mibios/glamr/views.py
+++ b/mibios/glamr/views.py
@@ -385,6 +385,7 @@ class MapMixin():
     def get_context_data(self, **ctx):
         ctx = super().get_context_data(**ctx)
         ctx['map_points'] = self.get_map_points()
+        ctx['fit_map_to_points'] = True
         return ctx
 
     def get_map_points(self):
@@ -989,6 +990,8 @@ class FrontPageView(SearchFormMixin, MapMixin, SingleTableView):
         ctx['dataset_totalcount'] = Dataset.objects.count()
         ctx['filtered_dataset_totalcount'] = self.filter.qs.distinct().count()
         ctx['sample_totalcount'] = Sample.objects.count()
+
+        ctx['fit_map_to_points'] = False  # showing the Great Lakes
 
         # Compile data for dataset summary: A list of the rows of the table,
         # for each cell it's a tuple of URL query string and value (text or


### PR DESCRIPTION
When the map is shown on pages besides the frontpage, fit map bounds to the displayed points.
Also moved map below title on dataset detail page for readability.