### PR TITLE
glamr: add interactive abundance charts for taxa and functions

### DIFF
--- a/mibios/glamr/templates/glamr/abundance.html
+++ b/mibios/glamr/templates/glamr/abundance.html
@@ -8,6 +8,141 @@
 <a href="{% record_url object %}">{{ object }}</a>
 </h3>
 {% include "glamr/download_links.html" %}
+
+{% if show_abundance_chart %}
+<div class="card my-4">
+  <div class="card-body">
+    <div class="d-flex align-items-center gap-3 mb-3 flex-wrap">
+      <span class="fw-semibold">Group by:</span>
+      <div class="btn-group btn-group-sm" role="group" aria-label="Chart grouping">
+        <input type="radio" class="btn-check" name="chart-group" id="group-all" value="" autocomplete="off" checked>
+        <label class="btn btn-outline-primary" for="group-all">All</label>
+        <input type="radio" class="btn-check" name="chart-group" id="group-lake" value="lake" autocomplete="off">
+        <label class="btn btn-outline-primary" for="group-lake">Lake</label>
+        <input type="radio" class="btn-check" name="chart-group" id="group-type" value="type" autocomplete="off">
+        <label class="btn btn-outline-primary" for="group-type">Sample type</label>
+        <input type="radio" class="btn-check" name="chart-group" id="group-both" value="both" autocomplete="off">
+        <label class="btn btn-outline-primary" for="group-both">Lake &amp; type</label>
+      </div>
+      <small id="chart-status" class="text-muted"></small>
+    </div>
+    <div style="position:relative;height:380px;">
+      <canvas id="abundance-chart" data-url="{{ chart_data_url }}"></canvas>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 {% render_table table %}
 {% endblock %}
 
+{% block bottom_of_body %}
+{{ block.super }}
+{% if show_abundance_chart %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+<script>
+(function () {
+  'use strict';
+  var canvasEl = document.getElementById('abundance-chart');
+  var statusEl = document.getElementById('chart-status');
+  var CHART_DATA_URL = canvasEl.dataset.url;
+
+  var COLORS = [
+    '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+    '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
+    '#aec7e8', '#ffbb78',
+  ];
+
+  var chart = null;
+
+  function buildDatasets(series) {
+    return series.map(function (s, i) {
+      return {
+        label: s.label,
+        data: s.data,
+        borderColor: COLORS[i % COLORS.length],
+        backgroundColor: COLORS[i % COLORS.length] + '33',
+        pointRadius: 4,
+        pointHoverRadius: 6,
+        tension: 0.1,
+        showLine: true,
+      };
+    });
+  }
+
+  function renderChart(series) {
+    var datasets = buildDatasets(series);
+    if (chart) {
+      chart.data.datasets = datasets;
+      chart.update();
+      return;
+    }
+    chart = new Chart(canvasEl, {
+      type: 'scatter',
+      data: { datasets: datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          x: {
+            type: 'time',
+            time: {
+              tooltipFormat: 'yyyy-MM-dd',
+              displayFormats: { month: 'MMM yyyy', year: 'yyyy' },
+            },
+            title: { display: true, text: 'Collection date' },
+          },
+          y: {
+            title: { display: true, text: 'Abundance (TPM)' },
+            beginAtZero: true,
+          },
+        },
+        plugins: {
+          tooltip: {
+            callbacks: {
+              afterBody: function (items) {
+                var pt = items[0] && items[0].raw;
+                return pt && pt.sample ? ['Sample: ' + pt.sample] : [];
+              },
+            },
+          },
+          legend: { position: 'bottom' },
+        },
+      },
+    });
+  }
+
+  function loadChart(groupBy) {
+    statusEl.textContent = 'Loading…';
+    var url = new URL(CHART_DATA_URL, window.location.href);
+    if (groupBy) {
+      url.searchParams.set('group_by', groupBy);
+    }
+    fetch(url, { credentials: 'same-origin' })
+      .then(function (resp) {
+        if (!resp.ok) { throw new Error(resp.statusText); }
+        return resp.json();
+      })
+      .then(function (json) {
+        if (!json.series.length) {
+          statusEl.textContent = 'No samples with collection dates.';
+          return;
+        }
+        renderChart(json.series);
+        statusEl.textContent = '';
+      })
+      .catch(function (e) {
+        statusEl.textContent = 'Chart error: ' + e.message;
+      });
+  }
+
+  document.querySelectorAll('input[name="chart-group"]').forEach(function (el) {
+    el.addEventListener('change', function () { loadChart(el.value); });
+  });
+
+  loadChart('');
+})();
+</script>
+{% endif %}
+{% endblock %}

--- a/mibios/glamr/templates/glamr/abundance.html
+++ b/mibios/glamr/templates/glamr/abundance.html
@@ -36,7 +36,7 @@
 {% render_table table %}
 {% endblock %}
 
-{% block bottom_of_body %}
+{% block body_bottom %}
 {{ block.super }}
 {% if show_abundance_chart %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>

--- a/mibios/glamr/urls0.py
+++ b/mibios/glamr/urls0.py
@@ -60,6 +60,7 @@ urlpatterns = [
     path('data/<str:model>/', views.TableView.disp_view, name='generic_table'),  # noqa: E501
     re_path(rf'data/(?P<model>\w+)/{kpat}/$', views.record_view, name='record'),  # noqa: E501
     path('data/<str:model>/<int:pk>/abundance/', views.AbundanceView.as_view(), name='record_abundance'),  # noqa: E501
+    path('data/<str:model>/<int:pk>/abundance/chart-data/', views.AbundanceChartDataView.as_view(), name='abundance_chart_data'),  # noqa: E501
     path('data/<str:model>/<int:pk>/abundance/<str:sample>/genes/', views.AbundanceGeneView.as_view(), name='record_abundance_genes'),  # noqa: E501
     path('data/<str:obj_model>/<int:pk>/relations/<str:field>/', views.ObjRelTableView.disp_view, name='relations'),  # noqa: E501
     path(download_url + '/<path:path>', views.FileDownloadView.as_view(), name='file_download'),  # noqa: E501

--- a/mibios/glamr/views.py
+++ b/mibios/glamr/views.py
@@ -1615,10 +1615,12 @@ class AbundanceView(MapMixin, BreadCrumbMixin, ModelTableMixin, BaseMixin,
         TaxonAbundance: {
             'table_class': tables.TaxonAbundanceTable,
             'sample_filter_key': 'seqsample__taxonabundance__taxon',
+            'chart_fk_field': 'taxon_id',
         },
         ReadAbundance: {
             'table_class': tables.ReadAbundanceTable,
             'sample_filter_key': 'seqsample__functional_abundance__ref',
+            'chart_fk_field': 'ref_id',
         },
         FuncAbundance: {
             'table_class': tables.FunctionAbundanceTable,
@@ -1700,6 +1702,13 @@ class AbundanceView(MapMixin, BreadCrumbMixin, ModelTableMixin, BaseMixin,
         ctx['model_name_verbose'] = self.model._meta.verbose_name
         ctx['object'] = self.object
         ctx['object_model_name'] = self.object_model._meta.model_name
+        obj_model_name = self.object_model._meta.model_name
+        if self.VIEW_ATTRS.get(obj_model_name, {}).get('chart_fk_field'):
+            ctx['show_abundance_chart'] = True
+            ctx['chart_data_url'] = reverse(
+                'abundance_chart_data',
+                kwargs={'model': obj_model_name, 'pk': self.object.pk},
+            )
         return ctx
 
     def get_sample_queryset(self):
@@ -1768,6 +1777,71 @@ class AbundanceGeneView(ModelTableMixin, BaseMixin, SingleTableView):
             return self.get_queryset().to_fasta()
         else:
             return super().get_values()
+
+
+class AbundanceChartDataView(View):
+    """JSON time-series abundance data for the abundance chart"""
+
+    def get(self, request, model, pk):
+        try:
+            attrs = AbundanceView.VIEW_ATTRS[model]
+        except KeyError:
+            from django.http import Http404
+            raise Http404(f'unsupported model: {model}')
+
+        fk_field = attrs.get('chart_fk_field')
+        if not fk_field:
+            from django.http import Http404
+            raise Http404(f'chart not supported for model: {model}')
+
+        abundance_model = attrs['model']
+        group_by = request.GET.get('group_by', '')
+
+        qs = (
+            abundance_model.objects
+            .filter(**{fk_field: pk})
+            .filter(sample__collection_timestamp__isnull=False)
+            .exclude(tpm__isnull=True)
+        )
+        qs = exclude_private_data(qs, request.user)
+        qs = qs.order_by('sample__collection_timestamp')
+
+        records = qs.values(
+            'tpm',
+            'sample__sample_id',
+            'sample__collection_timestamp',
+            'sample__geo_loc_name',
+            'sample__sample_type',
+        )
+
+        series = {}
+        for rec in records:
+            if group_by == 'lake':
+                key = rec['sample__geo_loc_name'] or 'Unknown'
+            elif group_by == 'type':
+                key = rec['sample__sample_type'] or 'Unknown'
+            elif group_by == 'both':
+                lake = rec['sample__geo_loc_name'] or 'Unknown'
+                stype = rec['sample__sample_type'] or 'Unknown'
+                key = f'{lake} / {stype}'
+            else:
+                key = 'All samples'
+
+            if key not in series:
+                series[key] = []
+
+            ts = rec['sample__collection_timestamp']
+            series[key].append({
+                'x': ts.strftime('%Y-%m-%d'),
+                'y': rec['tpm'],
+                'sample': rec['sample__sample_id'],
+            })
+
+        data = [
+            {'label': label, 'data': pts}
+            for label, pts in sorted(series.items())
+        ]
+        return JsonResponse({'series': data})
 
 
 class AvailableDataView(OpenBaseMixin, TemplateView):

--- a/mibios/glamr/views.py
+++ b/mibios/glamr/views.py
@@ -1615,12 +1615,14 @@ class AbundanceView(MapMixin, BreadCrumbMixin, ModelTableMixin, BaseMixin,
         TaxonAbundance: {
             'table_class': tables.TaxonAbundanceTable,
             'sample_filter_key': 'seqsample__taxonabundance__taxon',
-            'chart_fk_field': 'taxon_id',
+            'chart_object_fk': 'taxon',
+            'chart_abund_measure': 'tpm',
         },
         ReadAbundance: {
             'table_class': tables.ReadAbundanceTable,
             'sample_filter_key': 'seqsample__functional_abundance__ref',
-            'chart_fk_field': 'ref_id',
+            'chart_object_fk': 'ref',
+            'chart_abund_measure': 'tpm',
         },
         FuncAbundance: {
             'table_class': tables.FunctionAbundanceTable,
@@ -1633,6 +1635,8 @@ class AbundanceView(MapMixin, BreadCrumbMixin, ModelTableMixin, BaseMixin,
         FunctionNameAbundance: {
             'table_class': tables.FunctionNameAbundanceTable,
             'sample_filter_key': 'seqsample__function_name_abundance__name',
+            'chart_object_fk': 'name',
+            'chart_abund_measure': 'sum_tpm',
         },
     }
 
@@ -1702,12 +1706,14 @@ class AbundanceView(MapMixin, BreadCrumbMixin, ModelTableMixin, BaseMixin,
         ctx['model_name_verbose'] = self.model._meta.verbose_name
         ctx['object'] = self.object
         ctx['object_model_name'] = self.object_model._meta.model_name
-        obj_model_name = self.object_model._meta.model_name
-        if self.VIEW_ATTRS.get(obj_model_name, {}).get('chart_fk_field'):
+        if hasattr(self, 'chart_object_fk'):
             ctx['show_abundance_chart'] = True
             ctx['chart_data_url'] = reverse(
                 'abundance_chart_data',
-                kwargs={'model': obj_model_name, 'pk': self.object.pk},
+                kwargs={
+                    'model': self.object_model._meta.model_name,
+                    'pk': self.object.pk,
+                },
             )
         return ctx
 
@@ -1779,62 +1785,38 @@ class AbundanceGeneView(ModelTableMixin, BaseMixin, SingleTableView):
             return super().get_values()
 
 
-class AbundanceChartDataView(View):
+class AbundanceChartDataView(AbundanceView):
     """JSON time-series abundance data for the abundance chart"""
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        if not hasattr(self, 'chart_object_fk'):
+            raise Http404(f'chart not supported for model: {self.object_model}')
 
-    def get(self, request, model, pk):
-        try:
-            attrs = AbundanceView.VIEW_ATTRS[model]
-        except KeyError:
-            from django.http import Http404
-            raise Http404(f'unsupported model: {model}')
-
-        fk_field = attrs.get('chart_fk_field')
-        if not fk_field:
-            from django.http import Http404
-            raise Http404(f'chart not supported for model: {model}')
-
-        abundance_model = attrs['model']
-        group_by = request.GET.get('group_by', '')
-
-        qs = (
-            abundance_model.objects
-            .filter(**{fk_field: pk})
-            .filter(sample__collection_timestamp__isnull=False)
-            .exclude(tpm__isnull=True)
-        )
-        qs = exclude_private_data(qs, request.user)
-        qs = qs.order_by('sample__collection_timestamp')
-
-        records = qs.values(
-            'tpm',
-            'sample__sample_id',
-            'sample__collection_timestamp',
-            'sample__geo_loc_name',
-            'sample__sample_type',
-        )
+    def get(self, request, *args, **kwargs):
 
         series = {}
-        for rec in records:
-            if group_by == 'lake':
-                key = rec['sample__geo_loc_name'] or 'Unknown'
-            elif group_by == 'type':
-                key = rec['sample__sample_type'] or 'Unknown'
-            elif group_by == 'both':
-                lake = rec['sample__geo_loc_name'] or 'Unknown'
-                stype = rec['sample__sample_type'] or 'Unknown'
-                key = f'{lake} / {stype}'
-            else:
-                key = 'All samples'
+        for rec in self.get_queryset():
+            match request.GET.get('group_by', ''):
+                case 'lake':
+                    group = rec['sample__parent__geo_loc_name'] or 'Unknown'
+                case 'type':
+                    group = rec['sample__sample_type'] or 'Unknown'
+                case 'both':
+                    lake = rec['sample__parent__geo_loc_name'] or 'Unknown'
+                    stype = rec['sample__sample_type'] or 'Unknown'
+                    group = f'{lake} / {stype}'
+                case _:
+                    group = 'All samples'
 
-            if key not in series:
-                series[key] = []
+            if group not in series:
+                series[group] = []
 
-            ts = rec['sample__collection_timestamp']
-            series[key].append({
+            ts = rec['sample__parent__collection_timestamp']
+
+            series[group].append({
                 'x': ts.strftime('%Y-%m-%d'),
-                'y': rec['tpm'],
-                'sample': rec['sample__sample_id'],
+                'y': rec[self.chart_abund_measure],
+                'sample': rec['sample__parent__sample_id'],
             })
 
         data = [
@@ -1842,6 +1824,24 @@ class AbundanceChartDataView(View):
             for label, pts in sorted(series.items())
         ]
         return JsonResponse({'series': data})
+
+    def get_queryset(self):
+        qs = (
+            self.model.objects
+            .filter(**{self.chart_object_fk: self.object})
+            .exclude(sample__parent__collection_timestamp__isnull=True)
+            .exclude(**{f'{self.chart_abund_measure}__isnull': True})
+        )
+        qs = exclude_private_data(qs, self.request.user)
+        qs = qs.order_by('sample__parent__collection_timestamp')
+
+        return qs.values(
+            self.chart_abund_measure,
+            'sample__parent__sample_id',
+            'sample__parent__collection_timestamp',
+            'sample__parent__geo_loc_name',
+            'sample__sample_type',
+        )
 
 
 class AvailableDataView(OpenBaseMixin, TemplateView):


### PR DESCRIPTION
## Summary

- Adds an interactive Chart.js time-series chart to abundance pages for taxon (`/data/taxnode/<pk>/abundance/`) and functional (`/data/uniref100/<pk>/abundance/`) records
- Chart plots TPM abundance over collection date, with toggle buttons to group data by All / Lake / Sample type / Lake & type
- Adds a generic JSON endpoint `GET /data/<model>/<pk>/abundance/chart-data/` that returns chart data; enabled per-model via a new `chart_fk_field` key in `AbundanceView.VIEW_ATTRS`
- Private data is filtered from the chart endpoint via `exclude_private_data()`, consistent with the rest of the view

## Details

**New view:** `AbundanceChartDataView` — dispatches to the correct abundance model based on the `model` URL kwarg; returns `{series: [{label, data: [{x, y, sample}]}]}` JSON.

**New URL:** `data/<str:model>/<int:pk>/abundance/chart-data/` (name `abundance_chart_data`)

**Chart library:** Chart.js 4.4.0 + chartjs-adapter-date-fns 3.0.0, loaded from jsDelivr CDN only on pages that show the chart.

## Test plan

- [ ] Taxon abundance page shows chart with data points
- [ ] Functional (uniref100) abundance page shows chart with data points
- [ ] Group-by toggles (All / Lake / Sample type / Lake & type) update the chart correctly
- [ ] Pages with no samples having collection dates show "No samples with collection dates" message
- [ ] Unauthenticated users do not see private data in chart
- [ ] `funcrefdbentry` and `compoundrecord` abundance pages are unaffected (no chart, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)